### PR TITLE
feat: add Sources tab (closes #18) + fix year-filter bug in filter.R

### DIFF
--- a/filter.R
+++ b/filter.R
@@ -1,6 +1,6 @@
 # filter 
 f_filter <- function(min_year, max_year, my_country = "any", my_target="any") {
-  tb_sdg<-tb_sdg[tb_sdg2$Start<=max_year&
+  tb_sdg2<-tb_sdg2[tb_sdg2$Start<=max_year&
                      tb_sdg2$End>=min_year,]
   if (my_country !="any") {
     tb_sdg2 <- tb_sdg2[tb_sdg2$country==my_country,]

--- a/server.R
+++ b/server.R
@@ -6,4 +6,18 @@ server<-function(input,output){
                               input$target)})
   output$dTable<-renderDataTable({mytable()})
   
+  # Sources table: unique surveys with name, target(s), country count, year range, and access link
+  output$sourcesTable <- renderDataTable({
+    tb_sdg2 %>%
+      group_by(Name, Access) %>%
+      summarise(
+        Targets    = paste(sort(unique(as.character(target))), collapse = "; "),
+        Countries  = n_distinct(country),
+        Start_Year = min(Start, na.rm = TRUE),
+        End_Year   = max(End,   na.rm = TRUE),
+        .groups    = "drop"
+      ) %>%
+      arrange(Name)
+  }, escape = FALSE)
+  
 }

--- a/ui.R
+++ b/ui.R
@@ -24,7 +24,7 @@ ui <-fluidPage(
                         tabsetPanel(
                           # Data 
                           tabPanel(p(icon("table"), "shortform"),
-                                   h4('Datesets', align = "center"),
+                                   h4('Datasets', align = "center"),
                                    dataTableOutput(outputId = "dTable")
                           ), # end of "Dataset" tab panel
                           tabPanel(p(icon("table"), "longform"),
@@ -32,6 +32,13 @@ ui <-fluidPage(
                           ) # end of "Visualize the Data" tab panel
                         ))
                       ),
+             # Sources panel
+             tabPanel("Sources",
+                      h4('All Data Sources Included in This Database', align = "center"),
+                      p("This table lists all unique survey sources available in the SDG Locator database.",
+                        "Use it to identify which surveys are included and to spot any that may be missing."),
+                      dataTableOutput(outputId = "sourcesTable")
+             ),
              # about panel
              tabPanel("About",
                       h4('Number of Sets by Year', align = "center")


### PR DESCRIPTION
## Summary

- **Bug fix** (`filter.R`): The year-range filter was assigning filtered rows to `tb_sdg` (the raw import) instead of `tb_sdg2` (the processed long-form table). This meant the timeline slider had no effect. Fixed to assign to `tb_sdg2`.
- **Feature** (`ui.R`, `server.R`): Added a new top-level **Sources** tab (closes #18). It shows a deduplicated table of every survey in the database, with columns: Name, Access link, SDG Targets covered, number of Countries, Start Year, and End Year. This directly addresses the request from AFD/EVA colleagues to have a single place that lists all sources and makes it easy to spot what is missing.

## Changes

| File | Change |
|------|--------|
| `filter.R` | Fix variable name `tb_sdg` → `tb_sdg2` on the year-filter line |
| `ui.R` | Add `tabPanel("Sources", ...)` with `dataTableOutput("sourcesTable")` |
| `server.R` | Add `output$sourcesTable <- renderDataTable(...)` using `dplyr::group_by/summarise` on `tb_sdg2` |

## Test plan

- [ ] Launch the app and verify the **Explore the Data** tab: confirm the Timeline slider now actually filters rows (bug fix)
- [ ] Click the **Sources** tab and verify it renders a searchable table with one row per unique survey name
- [ ] Confirm the "Countries" count and year columns look correct for a few known surveys
- [ ] Confirm the Access column links are intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)